### PR TITLE
Minor bug fix

### DIFF
--- a/ray_marcher_demo.py
+++ b/ray_marcher_demo.py
@@ -278,7 +278,7 @@ if __name__ == '__main__':
 		# sleep until a key is pressed
 		event = pygame.event.wait()
 		if event.type == pygame.QUIT: sys.exit(0)
-		if event.type == pygame.KEYDOWN and event.unicode in '123456789':
+		if event.type == pygame.KEYDOWN and event.unicode in list('123456789'):
 			obj_render = menu[event.unicode][1]()
 			break
 	window = pygame.display.set_mode(win_size, OPENGL | DOUBLEBUF)


### PR DESCRIPTION
Fixed a small bug where keystrokes with different unicode values from those intended would return True due to the nature of using a string in the `in` statement and trigger a KeyError and cause the program to crash when comparing against the menu dict by switching to a list comparator instead of a string.